### PR TITLE
Update packetery.php

### DIFF
--- a/packetery/packetery.php
+++ b/packetery/packetery.php
@@ -894,11 +894,12 @@ END;
      */
     public function hookHeader($params)
     {
+        // need to able to overwrite
+        $this->context->controller->addJs(($this->_path).'views/js/front.js');
+        $this->context->controller->addCSS(($this->_path).'views/css/packetery.css');
+
         return '
-        <script type="text/javascript" src="' . self::WIDGET_URL . '"></script>
-        <script type="text/javascript" src="' . _MODULE_DIR_ . 'packetery/views/js/front.js?v=' . $this->version . '"></script>       
-        <link rel="stylesheet" href="' . _MODULE_DIR_ . 'packetery/views/css/packetery.css?v=' . $this->version . '" />
-        ';
+        <script type="text/javascript" src="' . self::WIDGET_URL . '"></script>';
     }
 
     /*


### PR DESCRIPTION
In some case you need to override default JS file. Prestashop provides the option to override the module JS and CSS file if there is an equivalent under the template. That is better way to add JS a CSS files.